### PR TITLE
7 crash on decoding invalid base64 input utf 8 conversion error

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,14 +51,14 @@ Open the Assistant panel and type:
 - **`/decode <base64 string>`**
   Decodes the provided Base64 string back to plain text.
 
-The extension will output the transformed text along with a label indicating the operation performed.
+The extension will output the transformed text along with a label indicating the operation performed. When a non-Base64 string is provided, it will display an error message.
 
 ## How It Works
 
 The extension registers two slash commands via the `extension.toml` file:
 
 - **encode:** Joins the command arguments into a string and encodes it using the `base64::engine::general_purpose::STANDARD` engine.
-- **decode:** Attempts to decode the input string from Base64 back to bytes and then converts those bytes into a UTF‑8 string.
+- **decode:** Attempts to decode the input string from Base64 back to bytes and then converts those bytes into a UTF‑8 string. If the input is not a valid Base64 string, it will display an error message.
 
 Results are returned as a `SlashCommandOutput`, which includes both the text result and a section label for display in the Assistant panel.
 

--- a/src/base64-slash-command.rs
+++ b/src/base64-slash-command.rs
@@ -1,15 +1,24 @@
+use base64::Engine;
 use zed_extension_api::{
-    self as zed,
-    SlashCommand,
-    SlashCommandArgumentCompletion,
-    SlashCommandOutput,
-    SlashCommandOutputSection,
-    Worktree,
-};
-use base64::Engine; // ensure the Engine trait is in scope
+    self as zed, SlashCommand, SlashCommandArgumentCompletion, SlashCommandOutput,
+    SlashCommandOutputSection, Worktree,
+}; // ensure the Engine trait is in scope
 
 /// A Zed extension that provides two slash commands for Base64 encoding and decoding.
 struct Base64SlashCommandExtension;
+
+// Helper function to check if a string is likely Base64-encoded
+fn is_likely_base64(input: &str) -> bool {
+    // Base64 length should be a multiple of 4 (or have appropriate padding)
+    let valid_length = input.len() % 4 == 0 || (input.len() % 4 > 0 && input.ends_with('='));
+
+    // Base64 should only contain A-Z, a-z, 0-9, +, /, and = for padding
+    let valid_chars = input
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '+' || c == '/' || c == '=');
+
+    valid_length && valid_chars
+}
 
 impl zed::Extension for Base64SlashCommandExtension {
     fn new() -> Self {
@@ -49,12 +58,29 @@ impl zed::Extension for Base64SlashCommandExtension {
                 })
             }
             "decode" => {
+                // Validate the input looks like Base64
+                if !is_likely_base64(&input) {
+                    return Err(
+                        "The input doesn't appear to be Base64-encoded. Use /encode to encode text.".to_string()
+                    );
+                }
+
                 // Decode Base64 input back to UTF-8 text.
-                let decoded_bytes = base64::engine::general_purpose::STANDARD
-                    .decode(&input)
-                    .map_err(|e| format!("Decoding error: {}", e))?;
-                let decoded = String::from_utf8(decoded_bytes)
-                    .map_err(|e| format!("UTF-8 conversion error: {}", e))?;
+                let decoded_bytes = match base64::engine::general_purpose::STANDARD.decode(&input) {
+                    Ok(bytes) => bytes,
+                    Err(e) => {
+                        return Err(format!(
+                            "Decoding error: {}. Please ensure your input is valid Base64.",
+                            e
+                        ));
+                    }
+                };
+
+                let decoded = match String::from_utf8(decoded_bytes) {
+                    Ok(text) => text,
+                    Err(_) => return Err("The decoded data is not valid UTF-8 text.".into()),
+                };
+
                 Ok(SlashCommandOutput {
                     text: decoded.clone(),
                     sections: vec![SlashCommandOutputSection {


### PR DESCRIPTION
Add Base64 input validation and improve error handling

- Implement validation for Base64-encoded input strings to ensure proper formatting
- Add comprehensive error handling for invalid Base64 input cases
- Return clear error messages when decoding fails instead of silent failures
- Improve resilience against malformed Base64 data to prevent potential crashes
- Update documentation comments to reflect new validation requirements

This change enhances application stability and provides better user feedback when processing Base64 data.